### PR TITLE
feat(Mapping::next_key): Replace base16 with base62

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ ruby "2.6.5"
 
 
 gem "autoprefixer-rails"
-
+gem 'bases'
 gem "bootsnap", require: false
 gem "bootstrap", '~> 4.4.1'
 gem "honeybadger"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
     autoprefixer-rails (9.7.5)
       execjs
     awesome_print (1.8.0)
+    bases (1.0.2)
     bindex (0.8.1)
     bitters (1.8.0)
       bourbon (~> 5.0)
@@ -280,6 +281,7 @@ PLATFORMS
 DEPENDENCIES
   autoprefixer-rails
   awesome_print
+  bases
   bootsnap
   bootstrap (~> 4.4.1)
   bundler-audit (>= 0.5.0)

--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -23,7 +23,11 @@ class Mapping < ApplicationRecord
   # hexadecimal representation
   def self.next_key
     next_id = (Mapping.maximum(:id)&.next || 0)
-    (next_id + 16).to_s(16)
+
+    # Seed between 0..63 will be single digit in base 62, so we offset by 62 to
+    # avoid this.
+    seed = (next_id + 62).to_s
+    Bases.val(seed).in_base(10).to_base(Bases::B62)
   end
 
   private


### PR DESCRIPTION
The `key` was convert via base 16, which means we can only only use `/0-9a-f/` to generate `key`.

So why not use `/0-9a-zA-Z/` instead, so that the length of `key` would not grow too fast.

This refactor is backward compatible and does not require any migration. Example below shows base 62 version `key`s (last 2 rows) co-exist with existing base 16 `key`s.

> ![image](https://user-images.githubusercontent.com/12410942/77547302-fc713600-6ee7-11ea-8c51-aeb8cd8be784.png)
